### PR TITLE
feat: added queue command, autocomplete fixes and node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
-    "start": "ts-node-esm src/index.ts",
+    "start": "node build/index.js",
+    "dev": "ts-node-esm src/index.ts",
     "lint": "eslint \"**/*.{js,ts}\"",
     "prepare": "husky install"
   },

--- a/src/commands/player/attachment.ts
+++ b/src/commands/player/attachment.ts
@@ -5,11 +5,15 @@ import { logger } from "../../lib/logger.js";
 import {
   type GuildMember,
   type MessageContextMenuCommandInteraction,
+  type MessageActionRowComponentBuilder,
   EmbedBuilder,
   ContextMenuCommandBuilder,
   ApplicationCommandType,
   SlashCommandBuilder,
   ChatInputCommandInteraction,
+  ButtonBuilder,
+  ActionRowBuilder,
+  ButtonStyle,
 } from "discord.js";
 import { useMasterPlayer } from "discord-player";
 
@@ -61,7 +65,20 @@ export const attachmentContextMenu: PlayerCommand = {
         }/${interaction.member!.user.avatar!}.png`,
       });
 
-      return await interaction.editReply({ embeds: [embed] });
+      const viewQueue = new ButtonBuilder()
+        .setCustomId("queue")
+        .setLabel("Xem queue")
+        .setStyle(ButtonStyle.Secondary);
+
+      const row =
+        new ActionRowBuilder<MessageActionRowComponentBuilder>().setComponents(
+          viewQueue
+        );
+
+      return await interaction.editReply({
+        embeds: [embed],
+        components: [row],
+      });
     } catch (e) {
       logger.error(e);
 
@@ -119,7 +136,20 @@ export const attachmentCommand: PlayerCommand = {
         }/${interaction.member!.user.avatar!}.png`,
       });
 
-      return await interaction.editReply({ embeds: [embed] });
+      const viewQueue = new ButtonBuilder()
+        .setCustomId("queue")
+        .setLabel("Xem queue")
+        .setStyle(ButtonStyle.Secondary);
+
+      const row =
+        new ActionRowBuilder<MessageActionRowComponentBuilder>().setComponents(
+          viewQueue
+        );
+
+      return await interaction.editReply({
+        embeds: [embed],
+        components: [row],
+      });
     } catch (e) {
       logger.error(e);
 

--- a/src/commands/player/queue.ts
+++ b/src/commands/player/queue.ts
@@ -1,0 +1,55 @@
+import type { PlayerCommand } from "../../types/command.js";
+
+import {
+  type CommandInteraction,
+  SlashCommandBuilder,
+  EmbedBuilder,
+} from "discord.js";
+import { useQueue } from "discord-player";
+
+export const queueCommand: PlayerCommand = {
+  data: new SlashCommandBuilder()
+    .setName("queue")
+    .setDescription("Azu-nyan sẽ cho bạn xem danh sách phát hiện tại OwO~"),
+  async execute(interaction: CommandInteraction) {
+    await interaction.deferReply();
+
+    const queue = useQueue(interaction.guild!.id);
+
+    if (!queue)
+      return await interaction.editReply("Hình như nhạc đang không chơi..?~");
+
+    const tracks = queue.tracks.toArray();
+    const currentTrack = queue.currentTrack;
+
+    if (!currentTrack)
+      return await interaction.editReply(
+        "Hiện không có bài nào trong danh sách phát~~"
+      );
+
+    const embed = new EmbedBuilder();
+
+    embed.setAuthor({ name: "Danh sách phát" });
+    embed.setColor("#e23622");
+    embed.setTitle("Hiện đang chơi");
+    embed.setDescription(`[${currentTrack.title}](${currentTrack.url})`);
+    embed.setThumbnail(currentTrack.thumbnail);
+
+    if (tracks.length > 0) {
+      embed.addFields(
+        {
+          name: "Sắp tới",
+          value: `${tracks.map(
+            (track, i) => `${i + 1}. [${track.title}](${track.url})`
+          )}`,
+        },
+        {
+          name: "Số lượng",
+          value: `${tracks.length} bài`,
+        }
+      );
+    }
+
+    return await interaction.editReply({ embeds: [embed] });
+  },
+};

--- a/src/commands/player/youtube.ts
+++ b/src/commands/player/youtube.ts
@@ -5,8 +5,12 @@ import { logger } from "../../lib/logger.js";
 import {
   type ChatInputCommandInteraction,
   type GuildMember,
+  type MessageActionRowComponentBuilder,
   EmbedBuilder,
   SlashCommandBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
 } from "discord.js";
 import { QueryType, useMasterPlayer } from "discord-player";
 
@@ -62,7 +66,20 @@ export const youtubeCommand: AutocompletePlayerCommand = {
         }/${interaction.member!.user.avatar!}.png`,
       });
 
-      return await interaction.editReply({ embeds: [embed] });
+      const viewQueue = new ButtonBuilder()
+        .setCustomId("queue")
+        .setLabel("Xem queue")
+        .setStyle(ButtonStyle.Secondary);
+
+      const row =
+        new ActionRowBuilder<MessageActionRowComponentBuilder>().setComponents(
+          viewQueue
+        );
+
+      return await interaction.editReply({
+        embeds: [embed],
+        components: [row],
+      });
     } catch (e) {
       logger.error(e);
 
@@ -95,6 +112,6 @@ export const youtubeCommand: AutocompletePlayerCommand = {
       })
     );
 
-    return interaction.respond(results);
+    return await interaction.respond(results);
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   attachmentCommand,
   attachmentContextMenu,
 } from "./commands/player/attachment.js";
+import { queueCommand } from "./commands/player/queue.js";
 
 dotenv.config();
 
@@ -42,6 +43,7 @@ const commands: PlayerCommand[] = [
   skipCommand,
   stopCommand,
   pingCommand,
+  queueCommand,
 ];
 
 await register(commands);
@@ -80,6 +82,23 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
     try {
       await command.execute(interaction);
+    } catch (e) {
+      logger.error(e);
+    }
+  }
+
+  if (interaction.isButton()) {
+    const action = commands.find(
+      (action) => action.data.name === interaction.customId
+    );
+
+    if (!action) {
+      logger.error(`Không thực thi được hành động ${interaction.customId}`);
+      return;
+    }
+
+    try {
+      await action.execute(interaction);
     } catch (e) {
       logger.error(e);
     }


### PR DESCRIPTION
## Describe your changes
- Added queue command `/queue`
- Added "view queue" button on queuing new songs
- Fixed autocomplete not working for `/yt`
- Changed `start` command from using `ts-node-esm` JIT to built `node`
- Added `dev` start script 